### PR TITLE
feat: Implement statistics endpoint

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -49,6 +49,28 @@ router.post("/shorten", (req, res) => {
   });
 });
 
+// GET /stats/:shortCode - Get statistics for a short URL
+router.get("/stats/:shortCode", (req, res) => {
+  const { shortCode } = req.params;
+
+  const urlData = storage.get(shortCode);
+
+  if (!urlData) {
+    return res.status(404).json({
+      error: "Short URL not found",
+      message: `No statistics found for short code: ${shortCode}`,
+    });
+  }
+
+  res.json({
+    shortCode: shortCode,
+    originalUrl: urlData.originalUrl,
+    clicks: urlData.clicks,
+    createdAt: urlData.createdAt,
+    shortUrl: `${config.baseUrl}/${shortCode}`,
+  });
+});
+
 // GET /:shortCode - Redirect to original URL
 router.get("/:shortCode", (req, res) => {
   const { shortCode } = req.params;


### PR DESCRIPTION
## Changes
- Implemented GET /stats/:shortCode endpoint
- Returns URL statistics:  clicks, creation date, original URL
- Returns 404 for non-existent short codes
- Properly ordered routes to prevent conflicts

## Testing
- [x] Returns correct statistics for existing URLs
- [x] Click count increments properly
- [x] Returns 404 for invalid codes
- [x] Stats route doesn't interfere with redirect

## Example
```bash
# Create short URL
curl -X POST http://localhost:3000/shorten \
  -H "Content-Type: application/json" \
  -d '{"url": "https://github.com"}'

# View statistics
curl http://localhost:3000/stats/aB3xYz
```

Closes #4