### PR TITLE
feat: Add health check and Prometheus metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,21 @@
     "": {
       "name": "tinylink",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "nodemon": "^3.1.11"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/accepts": {
@@ -57,6 +66,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -766,6 +780,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1010,6 +1036,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "author": "NidhalChelhi",
   "license": "MIT",
   "dependencies": {
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.11"

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,33 @@
 const express = require("express");
 const config = require("./config");
 const routes = require("./routes");
+const storage = require("./storage");
+const { register } = require("./metrics");
+const { metricsMiddleware } = require("./middleware");
 
 const app = express();
 
 // Middleware
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(metricsMiddleware);
+
+// Health check endpoint
+app.get("/health", (req, res) => {
+  res.json({
+    status: "healthy",
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+    service: "TinyLink",
+    version: "1.0.0",
+  });
+});
+
+// Metrics endpoint for Prometheus
+app.get("/metrics", async (req, res) => {
+  res.set("Content-Type", register.contentType);
+  res.end(await register.metrics());
+});
 
 // Root endpoint
 app.get("/", (req, res) => {
@@ -17,7 +38,9 @@ app.get("/", (req, res) => {
     endpoints: {
       shorten: "POST /shorten",
       redirect: "GET /:shortCode",
-      stats: "GET /stats/: shortCode",
+      stats: "GET /stats/:shortCode",
+      health: "GET /health",
+      metrics: "GET /metrics",
     },
   });
 });
@@ -29,4 +52,6 @@ app.use("/", routes);
 app.listen(config.port, () => {
   console.log(`🚀 TinyLink server running on port ${config.port}`);
   console.log(`📍 Environment: ${config.nodeEnv}`);
+  console.log(`💚 Health check: http://localhost:${config.port}/health`);
+  console.log(`📊 Metrics: http://localhost:${config.port}/metrics`);
 });

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1,0 +1,34 @@
+const client = require("prom-client");
+
+// Create a Registry
+const register = new client.Registry();
+
+// Add default metrics (CPU, memory, etc.)
+client.collectDefaultMetrics({ register });
+
+// Custom metrics
+const httpRequestDuration = new client.Histogram({
+  name: "http_request_duration_seconds",
+  help: "Duration of HTTP requests in seconds",
+  labelNames: ["method", "route", "status_code"],
+  registers: [register],
+});
+
+const urlsCreated = new client.Counter({
+  name: "urls_created_total",
+  help: "Total number of URLs shortened",
+  registers: [register],
+});
+
+const urlRedirects = new client.Counter({
+  name: "url_redirects_total",
+  help: "Total number of redirects performed",
+  registers: [register],
+});
+
+module.exports = {
+  register,
+  httpRequestDuration,
+  urlsCreated,
+  urlRedirects,
+};

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,19 @@
+const { httpRequestDuration } = require("./metrics");
+
+// Metrics middleware
+function metricsMiddleware(req, res, next) {
+  const start = Date.now();
+
+  res.on("finish", () => {
+    const duration = (Date.now() - start) / 1000;
+    httpRequestDuration
+      .labels(req.method, req.route?.path || req.path, res.statusCode)
+      .observe(duration);
+  });
+
+  next();
+}
+
+module.exports = {
+  metricsMiddleware,
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const storage = require("./storage");
 const { generateShortCode, isValidUrl } = require("./utils");
 const config = require("./config");
+const { urlsCreated, urlRedirects } = require("./metrics");
 
 const router = express.Router();
 
@@ -39,6 +40,9 @@ router.post("/shorten", (req, res) => {
 
   // Save to storage
   storage.save(shortCode, url);
+
+  // Increment metric
+  urlsCreated.inc();
 
   // Return response
   res.status(201).json({
@@ -87,6 +91,9 @@ router.get("/:shortCode", (req, res) => {
 
   // Increment click counter
   storage.incrementClicks(shortCode);
+
+  // Increment metric
+  urlRedirects.inc();
 
   // Redirect to original URL
   res.redirect(301, urlData.originalUrl);


### PR DESCRIPTION
## Changes
- Added GET /health endpoint with service status and uptime
- Added GET /metrics endpoint for Prometheus scraping
- Installed prom-client for metrics collection
- Added custom metrics: 
  - `urls_created_total` - Counter for shortened URLs
  - `url_redirects_total` - Counter for redirects
  - `http_request_duration_seconds` - Histogram for request latency
- Added metrics middleware to track all HTTP requests
- Updated root endpoint to list all available endpoints

## Testing
- [x] Health check returns proper status
- [x] Metrics endpoint returns Prometheus format
- [x] Custom metrics increment correctly
- [x] Default Node.js metrics included

## Example
```bash
# Check health
curl http://localhost:3000/health

# View metrics
curl http://localhost:3000/metrics
```

Closes #5