### PR TITLE
feat: Add Kubernetes deployment manifests

### DIFF
--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -1,0 +1,383 @@
+# Kubernetes Deployment Guide
+
+## Overview
+
+This guide explains how to deploy TinyLink to a Kubernetes cluster.
+
+## Prerequisites
+
+- Kubernetes cluster (v1.24+)
+- `kubectl` installed and configured
+- Docker image built (`tinylink:latest`)
+- Optional: Ingress controller (nginx)
+
+## Architecture
+
+```
+┌──────���──────────────────────────────┐
+│         Ingress (nginx)             │
+│      tinylink. local → Service       │
+└─────────────────┬───────────────────┘
+                  │
+┌─────────────────▼───────────────────┐
+│      Service (ClusterIP)            │
+│         Port 80 → 3000              │
+└─────────────────┬───────────────────┘
+                  │
+┌─────────────────▼───────────────────┐
+│        Deployment (3 replicas)      │
+│  ┌──────┐  ┌──────┐  ┌──────┐      │
+│  │ Pod1 │  │ Pod2 │  │ Pod3 │      │
+│  └──────┘  └──────┘  └──────┘      │
+└─────────────────────────────────────┘
+                  │
+        ┌─────────┴─────────┐
+        │                   │
+┌───────▼──────┐  ┌─────────▼────────┐
+│  ConfigMap   │  │       HPA        │
+│   (Config)   │  │  (Auto-scaling)  │
+└──────────────┘  └──────────────────┘
+```
+
+## Quick Start
+
+### Deploy Everything at Once
+
+```bash
+# Apply all manifests
+kubectl apply -f k8s/all-in-one.yaml
+
+# Check deployment status
+kubectl get all -n tinylink
+
+# Check pods are running
+kubectl get pods -n tinylink
+```
+
+### Deploy Step by Step
+
+```bash
+# 1. Create namespace
+kubectl apply -f k8s/namespace. yaml
+
+# 2. Create ConfigMap
+kubectl apply -f k8s/configmap.yaml
+
+# 3. Create Deployment
+kubectl apply -f k8s/deployment.yaml
+
+# 4. Create Service
+kubectl apply -f k8s/service.yaml
+
+# 5. Create Ingress (optional)
+kubectl apply -f k8s/ingress.yaml
+
+# 6. Create HPA (optional)
+kubectl apply -f k8s/hpa.yaml
+```
+
+## Verify Deployment
+
+### Check All Resources
+
+```bash
+# View all resources in tinylink namespace
+kubectl get all -n tinylink
+
+# Expected output:
+# NAME                            READY   STATUS    RESTARTS   AGE
+# pod/tinylink-xxx                1/1     Running   0          1m
+# pod/tinylink-yyy                1/1     Running   0          1m
+# pod/tinylink-zzz                1/1     Running   0          1m
+#
+# NAME                       TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)
+# service/tinylink-service   ClusterIP   10.96.100.100   <none>        80/TCP
+#
+# NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
+# deployment.apps/tinylink   3/3     3            3           1m
+```
+
+### Check Pod Status
+
+```bash
+# List pods
+kubectl get pods -n tinylink
+
+# Describe a pod
+kubectl describe pod <pod-name> -n tinylink
+
+# View pod logs
+kubectl logs <pod-name> -n tinylink
+
+# Follow logs
+kubectl logs -f <pod-name> -n tinylink
+```
+
+### Check Health
+
+```bash
+# Port-forward to access service
+kubectl port-forward -n tinylink svc/tinylink-service 8080:80
+
+# Test health endpoint (in another terminal)
+curl http://localhost:8080/health
+```
+
+## Testing the Application
+
+### Port Forward Method
+
+```bash
+# Forward service port to localhost
+kubectl port-forward -n tinylink svc/tinylink-service 8080:80
+
+# Test in another terminal
+# Shorten URL
+curl -X POST http://localhost:8080/shorten \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://github.com"}'
+
+# Check health
+curl http://localhost:8080/health
+
+# View metrics
+curl http://localhost:8080/metrics
+```
+
+### Using Ingress (if configured)
+
+```bash
+# Add to /etc/hosts
+echo "127.0.0.1 tinylink.local" | sudo tee -a /etc/hosts
+
+# Access via browser or curl
+curl http://tinylink.local/health
+```
+
+## Scaling
+
+### Manual Scaling
+
+```bash
+# Scale to 5 replicas
+kubectl scale deployment tinylink -n tinylink --replicas=5
+
+# Check scaling
+kubectl get pods -n tinylink
+```
+
+### Auto-Scaling (HPA)
+
+```bash
+# Check HPA status
+kubectl get hpa -n tinylink
+
+# Describe HPA
+kubectl describe hpa tinylink-hpa -n tinylink
+
+# Watch HPA in action
+kubectl get hpa -n tinylink --watch
+```
+
+## Configuration
+
+### Update ConfigMap
+
+```bash
+# Edit ConfigMap
+kubectl edit configmap tinylink-config -n tinylink
+
+# Or apply updated file
+kubectl apply -f k8s/configmap.yaml
+
+# Restart pods to pick up changes
+kubectl rollout restart deployment tinylink -n tinylink
+```
+
+### Update Image
+
+```bash
+# Update deployment with new image
+kubectl set image deployment/tinylink \
+  tinylink=tinylink:v2 \
+  -n tinylink
+
+# Check rollout status
+kubectl rollout status deployment/tinylink -n tinylink
+
+# Rollback if needed
+kubectl rollout undo deployment/tinylink -n tinylink
+```
+
+## Resource Management
+
+### View Resource Usage
+
+```bash
+# Pod resource usage
+kubectl top pods -n tinylink
+
+# Node resource usage
+kubectl top nodes
+```
+
+### Resource Quotas
+
+The deployment includes:
+
+- **Requests:** 128Mi memory, 100m CPU per pod
+- **Limits:** 256Mi memory, 200m CPU per pod
+- **HPA:** 2-10 replicas based on 70% CPU / 80% memory
+
+## Troubleshooting
+
+### Pods Not Starting
+
+```bash
+# Check pod events
+kubectl describe pod <pod-name> -n tinylink
+
+# Common issues:
+# - ImagePullBackOff:  Docker image not found
+# - CrashLoopBackOff:  Application crashes on startup
+# - Pending: Insufficient resources
+```
+
+### Check Logs
+
+```bash
+# View logs
+kubectl logs <pod-name> -n tinylink
+
+# View previous container logs (if crashed)
+kubectl logs <pod-name> -n tinylink --previous
+
+# Stream logs from all pods
+kubectl logs -f -l app=tinylink -n tinylink
+```
+
+### Health Check Failures
+
+```bash
+# Check if health endpoint responds
+kubectl exec -it <pod-name> -n tinylink -- curl localhost:3000/health
+
+# Check pod events
+kubectl get events -n tinylink --sort-by='. lastTimestamp'
+```
+
+### Service Not Accessible
+
+```bash
+# Check service endpoints
+kubectl get endpoints -n tinylink
+
+# Check if pods are ready
+kubectl get pods -n tinylink
+
+# Test service from within cluster
+kubectl run -it --rm debug --image=curlimages/curl --restart=Never \
+  -- curl http://tinylink-service. tinylink.svc.cluster.local/health
+```
+
+## Cleanup
+
+### Delete Everything
+
+```bash
+# Delete all resources
+kubectl delete -f k8s/all-in-one.yaml
+
+# Or delete namespace (removes everything)
+kubectl delete namespace tinylink
+```
+
+### Delete Specific Resources
+
+```bash
+# Delete HPA
+kubectl delete hpa tinylink-hpa -n tinylink
+
+# Delete Ingress
+kubectl delete ingress tinylink-ingress -n tinylink
+
+# Delete Service
+kubectl delete service tinylink-service -n tinylink
+
+# Delete Deployment
+kubectl delete deployment tinylink -n tinylink
+```
+
+## Production Considerations
+
+### Security
+
+- Use Secrets for sensitive data (not ConfigMap)
+- Enable RBAC
+- Use Network Policies
+- Set security contexts
+
+### High Availability
+
+- Run across multiple nodes
+- Use Pod Disruption Budgets
+- Configure proper resource requests/limits
+- Set up monitoring and alerting
+
+### Persistence
+
+- Add PersistentVolumeClaims if needed
+- Use external databases (PostgreSQL, Redis)
+- Configure backup strategies
+
+### Monitoring
+
+- Deploy Prometheus for metrics
+- Set up Grafana dashboards
+- Configure alerting rules
+- Enable distributed tracing
+
+## Manifest Details
+
+### Namespace
+
+- Isolates TinyLink resources
+- Environment label for organization
+
+### ConfigMap
+
+- Stores non-sensitive configuration
+- Environment variables for the app
+
+### Deployment
+
+- 3 replicas for high availability
+- Rolling update strategy
+- Health probes (liveness + readiness)
+- Resource limits and requests
+
+### Service
+
+- ClusterIP type (internal access)
+- Load balances across pods
+- Port 80 → 3000 mapping
+
+### Ingress
+
+- External access via domain
+- nginx ingress controller
+- Host-based routing
+
+### HPA
+
+- Auto-scales 2-10 replicas
+- Based on CPU (70%) and memory (80%)
+- Smart scale-up/scale-down policies
+
+## Next Steps
+
+- Set up monitoring (Prometheus + Grafana)
+- Add persistent storage
+- Configure TLS/SSL certificates
+- Implement CI/CD integration
+- Set up multi-environment (dev, staging, prod)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# TinyLink - URL Shortener
+# TinyLink – URL Shortener
 
 [![CI Pipeline](https://github.com/NidhalChelhi/tinylink/actions/workflows/ci.yml/badge.svg)](https://github.com/NidhalChelhi/tinylink/actions/workflows/ci.yml)
 [![CD Pipeline](https://github.com/NidhalChelhi/tinylink/actions/workflows/cd.yml/badge.svg)](https://github.com/NidhalChelhi/tinylink/actions/workflows/cd.yml)
 
-A simple, fast, and production-ready URL shortening service built with Node.js and Express.
+A simple, fast, and production-ready URL shortening service built with **Node.js** and **Express**.
 
-## Features
+---
 
-- 🔗 URL Shortening with unique 6-character codes
+## ✨ Features
+
+- 🔗 URL shortening with unique 6-character codes
 - ↪️ Fast redirects with click tracking
 - 📊 Statistics endpoint for analytics
 - 🏥 Health check endpoint
@@ -15,8 +17,11 @@ A simple, fast, and production-ready URL shortening service built with Node.js a
 - 📝 Structured logging with Winston
 - ✅ Input validation and error handling
 - 🐳 Docker support
+- ☸️ Kubernetes deployment ready
 
-## Quick Start
+---
+
+## 🚀 Quick Start
 
 ### Using Docker (Recommended)
 
@@ -32,6 +37,8 @@ docker-compose up -d
 curl http://localhost:3000/health
 ```
 
+---
+
 ### Using Node.js
 
 ```bash
@@ -45,56 +52,165 @@ npm run dev
 npm start
 ```
 
-## API Endpoints
+---
+
+### Using Kubernetes
+
+```bash
+# Deploy to Kubernetes cluster
+kubectl apply -f k8s/all-in-one.yaml
+
+# Check deployment status
+kubectl get pods -n tinylink
+
+# Access via port-forward
+kubectl port-forward -n tinylink svc/tinylink-service 8080:80
+curl http://localhost:8080/health
+```
+
+---
+
+## 📡 API Endpoints
 
 ### Shorten URL
 
-```bash
+```http
 POST /shorten
 Content-Type: application/json
+```
 
+```json
 {
   "url": "https://example.com"
 }
 ```
 
+**Response**
+
+```json
+{
+  "originalUrl": "https://example.com",
+  "shortUrl": "http://localhost:3000/aBc123",
+  "shortCode": "aBc123",
+  "createdAt": "2026-01-15T10:30:00.000Z"
+}
+```
+
+---
+
 ### Redirect
 
-```bash
+```http
 GET /:shortCode
 ```
 
+Redirects to the original URL with **301** status code.
+
+---
+
 ### Get Statistics
 
-```bash
+```http
 GET /stats/:shortCode
 ```
 
+**Response**
+
+```json
+{
+  "shortCode": "aBc123",
+  "originalUrl": "https://example.com",
+  "clicks": 42,
+  "createdAt": "2026-01-15T10:30:00.000Z",
+  "shortUrl": "http://localhost:3000/aBc123"
+}
+```
+
+---
+
 ### Health Check
 
-```bash
+```http
 GET /health
 ```
 
+**Response**
+
+```json
+{
+  "status": "healthy",
+  "uptime": 123.45,
+  "timestamp": "2026-01-15T10:30:00.000Z",
+  "service": "TinyLink",
+  "version": "1.0.0"
+}
+```
+
+---
+
 ### Prometheus Metrics
 
-```bash
+```http
 GET /metrics
 ```
 
-## Docker
+Returns metrics in **Prometheus format**.
 
-See [DOCKER.md](DOCKER.md) for detailed Docker deployment instructions.
+---
 
-## Environment Variables
+## 📦 Deployment
 
-```env
-NODE_ENV=development    # development | production
-PORT=3000              # Server port
-BASE_URL=http://localhost:3000  # Base URL for short links
+### Docker
+
+See [DOCKER.md](DOCKER.md) for detailed instructions.
+
+```bash
+# Build image
+docker build -t tinylink:latest .
+
+# Run container
+docker run -d -p 3000:3000 tinylink:latest
+
+# Using Docker Compose
+docker-compose up -d
 ```
 
-## Development
+---
+
+### Kubernetes
+
+See [KUBERNETES.md](KUBERNETES.md) for full documentation.
+
+```bash
+# Deploy everything
+kubectl apply -f k8s/all-in-one.yaml
+
+# Check status
+kubectl get all -n tinylink
+
+# View logs
+kubectl logs -f -l app=tinylink -n tinylink
+
+# Scale deployment
+kubectl scale deployment tinylink -n tinylink --replicas=5
+
+# Delete deployment
+kubectl delete -f k8s/all-in-one.yaml
+```
+
+---
+
+## ⚙️ Environment Variables
+
+```env
+NODE_ENV=development           # development | production
+PORT=3000                      # Server port
+BASE_URL=http://localhost:3000 # Base URL for short links
+```
+
+---
+
+## 🛠️ Development
 
 ```bash
 # Install dependencies
@@ -103,11 +219,16 @@ npm install
 # Run development server
 npm run dev
 
-# Run tests (if available)
+# Run tests
 npm test
+
+# Run linter
+npm run lint
 ```
 
-## Technology Stack
+---
+
+## 🧰 Technology Stack
 
 - **Runtime:** Node.js 18
 - **Framework:** Express.js
@@ -115,32 +236,127 @@ npm test
 - **Logging:** Winston
 - **Metrics:** prom-client (Prometheus)
 - **Containerization:** Docker & Docker Compose
+- **Orchestration:** Kubernetes
 
-## Project Structure
+---
 
-```
+## 📁 Project Structure
+
+```text
 tinylink/
 ├── src/
-│   ├── index.js          # Main server file
-│   ├── routes.js         # API routes
-│   ├── storage.js        # In-memory storage
-│   ├── utils.js          # Utilities
-│   ├── config.js         # Configuration
-│   ├── logger.js         # Winston logger
-│   ├── metrics.js        # Prometheus metrics
-│   ├── middleware.js     # Express middleware
-│   ├── validation.js     # Joi schemas
-│   └── errors.js         # Custom error classes
-├── Dockerfile            # Docker image definition
-├── docker-compose.yml    # Docker Compose configuration
-├── package.json          # Dependencies
-└── README.md            # This file
+│   ├── index.js
+│   ├── routes.js
+│   ├── storage.js
+│   ├── utils.js
+│   ├── config.js
+│   ├── logger.js
+│   ├── metrics.js
+│   ├── middleware.js
+│   ├── validation.js
+│   └── errors.js
+├── k8s/
+│   ├── namespace.yaml
+│   ├── configmap.yaml
+│   ├── deployment.yaml
+│   ├── service.yaml
+│   ├── ingress.yaml
+│   ├── hpa.yaml
+│   └── all-in-one.yaml
+├── .github/
+│   ├── workflows/
+│   │   ├── ci.yml
+│   │   └── cd.yml
+│   └── dependabot.yml
+├── Dockerfile
+├── docker-compose.yml
+├── package.json
+├── DOCKER.md
+├── KUBERNETES.md
+├── CI-CD.md
+└── README.md
 ```
 
-## License
+---
+
+## 🔄 CI/CD Pipeline
+
+**GitHub Actions** is used for CI/CD.
+
+### CI Pipeline
+
+- Linting and testing
+- Docker image build
+- Security scanning with Trivy
+
+### CD Pipeline
+
+- Runs on merge to `main`
+- Builds production Docker images
+- Tags images with version & commit SHA
+- Simulated staging deployment
+
+See [CI-CD.md](CI-CD.md) for details.
+
+---
+
+## 📊 Monitoring & Observability
+
+### Health Check
+
+```bash
+curl http://localhost:3000/health
+```
+
+### Metrics
+
+```bash
+curl http://localhost:3000/metrics
+```
+
+**Available metrics**
+
+- `urls_created_total`
+- `url_redirects_total`
+- `http_request_duration_seconds`
+- Default Node.js metrics (CPU, memory)
+
+---
+
+## 🧪 Testing
+
+```bash
+npm test
+npm run test:watch
+npm test -- --coverage
+```
+
+---
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Commit your changes
+4. Push to your branch
+5. Open a Pull Request
+
+---
+
+## 📄 License
 
 MIT
 
-## Author
+---
 
-Nidhal Chelhi
+## 👤 Author
+
+**Nidhal Chelhi**
+
+---
+
+## 🔗 Links
+
+- Repository: [https://github.com/NidhalChelhi/tinylink](https://github.com/NidhalChelhi/tinylink)
+- Issues: [https://github.com/NidhalChelhi/tinylink/issues](https://github.com/NidhalChelhi/tinylink/issues)
+- GitHub Actions: [https://github.com/NidhalChelhi/tinylink/actions](https://github.com/NidhalChelhi/tinylink/actions)

--- a/k8s/all-in-one.yaml
+++ b/k8s/all-in-one.yaml
@@ -1,0 +1,162 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tinylink
+  labels:
+    app: tinylink
+    environment: production
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tinylink-config
+  namespace: tinylink
+  labels:
+    app: tinylink
+data:
+  NODE_ENV: "production"
+  PORT: "3000"
+  BASE_URL: "http://tinylink.local"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tinylink
+  namespace: tinylink
+  labels:
+    app: tinylink
+    version: v1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: tinylink
+  template:
+    metadata:
+      labels:
+        app: tinylink
+        version: v1
+    spec:
+      containers:
+        - name: tinylink
+          image: tinylink:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: tinylink-config
+                  key: NODE_ENV
+            - name: PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: tinylink-config
+                  key: PORT
+            - name: BASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: tinylink-config
+                  key: BASE_URL
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tinylink-service
+  namespace: tinylink
+  labels:
+    app: tinylink
+spec:
+  type: ClusterIP
+  selector:
+    app: tinylink
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+      protocol: TCP
+  sessionAffinity: None
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tinylink-ingress
+  namespace: tinylink
+  labels:
+    app: tinylink
+  annotations:
+    nginx. ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: tinylink.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tinylink-service
+                port:
+                  number: 80
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: tinylink-hpa
+  namespace: tinylink
+  labels:
+    app: tinylink
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tinylink
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tinylink-config
+  namespace: tinylink
+  labels:
+    app: tinylink
+data:
+  NODE_ENV: "production"
+  PORT: "3000"
+  BASE_URL: "http://tinylink.local"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tinylink
+  namespace: tinylink
+  labels:
+    app: tinylink
+    version: v1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: tinylink
+  template:
+    metadata:
+      labels:
+        app: tinylink
+        version: v1
+    spec:
+      containers:
+        - name: tinylink
+          image: tinylink:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: tinylink-config
+                  key: NODE_ENV
+            - name: PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: tinylink-config
+                  key: PORT
+            - name: BASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: tinylink-config
+                  key: BASE_URL
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+      restartPolicy: Always

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,44 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: tinylink-hpa
+  namespace: tinylink
+  labels:
+    app: tinylink
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tinylink
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+        - type: Pods
+          value: 2
+          periodSeconds: 30
+      selectPolicy: Max

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tinylink-ingress
+  namespace: tinylink
+  labels:
+    app: tinylink
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: tinylink.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tinylink-service
+                port:
+                  number: 80

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tinylink
+  labels:
+    app: tinylink
+    environment: production

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tinylink-service
+  namespace: tinylink
+  labels:
+    app: tinylink
+spec:
+  type: ClusterIP
+  selector:
+    app: tinylink
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+      protocol: TCP
+  sessionAffinity: None


### PR DESCRIPTION
## Changes
- Created complete Kubernetes deployment configuration
- Added individual manifests for each resource type
- Created all-in-one manifest for easy deployment
- Comprehensive KUBERNETES.md documentation

## Kubernetes Resources

### Namespace
- Isolates TinyLink resources
- Production environment label

### ConfigMap
- Stores application configuration
- Environment variables (NODE_ENV, PORT, BASE_URL)

### Deployment
- 3 replicas for high availability
- Rolling update strategy
- Health probes (liveness + readiness)
- Resource limits:  256Mi memory, 200m CPU
- Resource requests: 128Mi memory, 100m CPU

### Service
- ClusterIP type for internal access
- Load balances across pods
- Port 80 → 3000 mapping

### Ingress
- External access via tinylink.local
- nginx ingress controller support
- Path-based routing

### HorizontalPodAutoscaler
- Auto-scales between 2-10 replicas
- Based on CPU (70%) and memory (80%) utilization
- Smart scale-up/scale-down policies

## Deployment

```bash
# Deploy everything
kubectl apply -f k8s/all-in-one.yaml

# Check status
kubectl get all -n tinylink

# Test with port-forward
kubectl port-forward -n tinylink svc/tinylink-service 8080:80
curl http://localhost:8080/health
```
## Documentation
- Complete deployment guide
- Troubleshooting section
- Scaling instructions
- Production considerations

Closes #11